### PR TITLE
bumblebee: Add support for AlwaysUnloadKernelDriver

### DIFF
--- a/copr/bumblebee/bumblebee/0001-Add-option-to-always-unload-the-driver-on-exit.patch
+++ b/copr/bumblebee/bumblebee/0001-Add-option-to-always-unload-the-driver-on-exit.patch
@@ -1,0 +1,87 @@
+From 554e84e6a5335ea831248685058239af748c99c2 Mon Sep 17 00:00:00 2001
+From: Marcin Jaworski <marcin@jaworski.me>
+Date: Thu, 23 Aug 2018 00:43:26 +0200
+Subject: [PATCH] Add option to always unload the driver on exit
+
+---
+ src/bbconfig.c    |  4 ++++
+ src/bbconfig.h    |  1 +
+ src/bbsecondary.c | 27 +++++++++++++++++----------
+ 3 files changed, 22 insertions(+), 10 deletions(-)
+
+diff --git a/src/bbconfig.c b/src/bbconfig.c
+index 62a3306..6303778 100644
+--- a/src/bbconfig.c
++++ b/src/bbconfig.c
+@@ -462,6 +462,10 @@ void bbconfig_parse_conf_driver(GKeyFile *bbcfg, char *driver) {
+       g_free(module_name);
+     }
+   }
++  key = "AlwaysUnloadKernelDriver";
++  if (g_key_file_has_key(bbcfg, section, key, NULL)) {
++    bb_config.force_driver_unload = g_key_file_get_boolean(bbcfg, section, key, NULL);
++  }
+   key = "LibraryPath";
+   if (g_key_file_has_key(bbcfg, section, key, NULL)) {
+     free_and_set_value(&bb_config.ld_path, g_key_file_get_string(bbcfg, section, key, NULL));
+diff --git a/src/bbconfig.h b/src/bbconfig.h
+index a19f5d3..13c9517 100644
+--- a/src/bbconfig.h
++++ b/src/bbconfig.h
+@@ -145,6 +145,7 @@ struct bb_config_struct {
+     char * module_name; /* Kernel module to be loaded for the driver.
+                                     * If empty, driver will be used. This is
+                                     * for Ubuntu which uses nvidia-current */
++    int force_driver_unload; /* Force driver unload, even without active PM method */
+     int card_shutdown_state;
+ #ifdef WITH_PIDFILE
+     char *pid_file; /* pid file for storing the daemons PID */
+diff --git a/src/bbsecondary.c b/src/bbsecondary.c
+index 21b1e35..b1e3158 100644
+--- a/src/bbsecondary.c
++++ b/src/bbsecondary.c
+@@ -225,24 +225,31 @@ bool start_secondary(bool need_secondary) {
+ static void switch_and_unload(void)
+ {
+   char driver[BUFFER_SIZE];
++  int unload_driver = 0;
+ 
+-  if (bb_config.pm_method == PM_DISABLED && bb_status.runmode != BB_RUN_EXIT) {
++  if (bb_config.pm_method == PM_DISABLED && !bb_config.force_driver_unload && bb_status.runmode != BB_RUN_EXIT) {
+     /* do not disable the card if PM is disabled unless exiting */
+     return;
+   }
+ 
+   //if card is on and can be switched, switch it off
++  if (switcher && switcher->need_driver_unloaded) {
++    /* do not unload the drivers nor disable the card if the card is not on */
++    if (switcher->status() != SWITCH_ON) {
++      return;
++    }
++    unload_driver = 1;
++  }
++
++  if (unload_driver || bb_config.force_driver_unload) {
++    /* unload the driver loaded by the graphica card */
++    if (pci_get_driver(driver, pci_bus_id_discrete, sizeof driver)) {
++      module_unload(driver);
++    }
++  }
++
+   if (switcher) {
+     if (switcher->need_driver_unloaded) {
+-      /* do not unload the drivers nor disable the card if the card is not on */
+-      if (switcher->status() != SWITCH_ON) {
+-        return;
+-      }
+-      /* unload the driver loaded by the graphica card */
+-      if (pci_get_driver(driver, pci_bus_id_discrete, sizeof driver)) {
+-        module_unload(driver);
+-      }
+-
+       //only turn card off if no drivers are loaded
+       if (pci_get_driver(NULL, pci_bus_id_discrete, 0)) {
+         bb_log(LOG_DEBUG, "Drivers are still loaded, unable to disable card\n");
+-- 
+2.20.1
+

--- a/copr/bumblebee/bumblebee/bumblebee.spec
+++ b/copr/bumblebee/bumblebee/bumblebee.spec
@@ -3,7 +3,7 @@
 
 Name:           bumblebee
 Version:        3.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Daemon to support NVIDIA Optimus via VirtualGL
 
 License:        GPLv3+
@@ -26,6 +26,7 @@ Patch7:         0008-libglvnd.patch
 Patch10:        0001-Execute-usr-libexec-Xorg.wrap-instead-of-Xorg.patch
 Patch11:        0002-xorg.conf.nvidia-Treat-ABI-mismatch-as-warning.patch
 Patch12:        0003-bumblebee-bugreport-Add-support-for-Fedora.patch
+Patch13:        0001-Add-option-to-always-unload-the-driver-on-exit.patch
 
 BuildRequires:  help2man
 BuildRequires:  systemd
@@ -33,12 +34,12 @@ BuildRequires:  systemd
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(x11)
 
-Requires:       bbswitch-kmod
 Requires:       VirtualGL
 Requires(pre):  shadow-utils
 
 Requires:       %{name}-selinux = %{version}-%{release}
 
+Recommends:     bbswitch-kmod
 Recommends:     primus
 
 %{?systemd_requires}
@@ -166,6 +167,9 @@ fi
 
 
 %changelog
+* Sat Aug 03 2019 Elia Geretto <elia.f.geretto@gmail.com> - 3.2.1-3
+- Add support for AlwaysUnloadKernelDriver
+
 * Mon Dec 25 2017 Andrew Gunnerson <andrewgunnerson@gmail.com> - 3.2.1-2
 - Add -selinux subpackage that allows bumblebeed to write to /proc/acpi/bbswitch
 


### PR DESCRIPTION
The commit used to generate the patch is: https://github.com/Bumblebee-Project/Bumblebee/commit/554e84e6a5335ea831248685058239af748c99c2

The issue that led to the introduction of this feature is explained extensively in the pull request associated with it: https://github.com/Bumblebee-Project/Bumblebee/pull/983